### PR TITLE
Filter PyLint messages which occur in assertion statements

### DIFF
--- a/pytest_encourage/util.py
+++ b/pytest_encourage/util.py
@@ -1,0 +1,20 @@
+""" Utility functions """
+import json
+from typing import List, Dict, Union
+
+def read_source_file(filepath: str) -> List[str]:
+    """ Decorator which reads the lines of a file and passes as arg to func """
+    with open(filepath, "r") as f:
+        lines = f.read().split("\n")
+        return lines
+
+def lint_message_is_in_assertion(msg: Dict[str, Union[str, int]]):
+    """ Checks whether a PyLint message is referring to an assert statement """
+    path, line_num = msg["path"], msg["line"]
+    line = read_source_file(path)[line_num - 1] # Line numbers start with 1, not 0
+    line = line.strip() # Remove indentation from start of line
+    return line.startswith("assert")
+
+def pylint_assertion_messages(pylint_json_string):
+    msgs = json.loads(pylint_json_string)
+    return list(filter(lint_message_is_in_assertion, msgs))

--- a/pytest_encourage/util.py
+++ b/pytest_encourage/util.py
@@ -2,19 +2,23 @@
 import json
 from typing import List, Dict, Union
 
+
 def read_source_file(filepath: str) -> List[str]:
     """ Decorator which reads the lines of a file and passes as arg to func """
     with open(filepath, "r") as f:
         lines = f.read().split("\n")
         return lines
 
+
 def lint_message_is_in_assertion(msg: Dict[str, Union[str, int]]):
     """ Checks whether a PyLint message is referring to an assert statement """
     path, line_num = msg["path"], msg["line"]
-    line = read_source_file(path)[line_num - 1] # Line numbers start with 1, not 0
-    line = line.strip() # Remove indentation from start of line
+    line = read_source_file(path)[line_num - 1]  # Line numbers start with 1, not 0
+    line = line.strip()  # Remove indentation from start of line
     return line.startswith("assert")
 
+
 def pylint_assertion_messages(pylint_json_string):
+    """ Filters PyLint output to include only messages referring to assert statements """
     msgs = json.loads(pylint_json_string)
     return list(filter(lint_message_is_in_assertion, msgs))

--- a/pytest_encourage/util.py
+++ b/pytest_encourage/util.py
@@ -26,7 +26,7 @@ def lint_message_is_in_assertion(msg: LintMsg) -> bool:
 
 
 def filter_assertions(msgs: Union[str, List[LintMsg]]) -> List[LintMsg]:
-    """ Filters Pylint output to include only messages which referring to
+    """ Filters Pylint output to include only messages which refer to
         assert statements """
     if isinstance(msgs, str):
         msgs = json.loads(msgs)

--- a/pytest_encourage/util.py
+++ b/pytest_encourage/util.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Union
 
 def read_source_file(filepath: str) -> List[str]:
     """ Decorator which reads the lines of a file and passes as arg to func """
+    # pylint: disable=invalid-name
     with open(filepath, "r") as f:
         lines = f.read().split("\n")
         return lines
@@ -13,12 +14,15 @@ def read_source_file(filepath: str) -> List[str]:
 def lint_message_is_in_assertion(msg: Dict[str, Union[str, int]]):
     """ Checks whether a PyLint message is referring to an assert statement """
     path, line_num = msg["path"], msg["line"]
-    line = read_source_file(path)[line_num - 1]  # Line numbers start with 1, not 0
-    line = line.strip()  # Remove indentation from start of line
+    # Line numbers start with 1, not 0
+    line = read_source_file(path)[line_num - 1]
+    # Remove indentation from start of line
+    line = line.strip()
     return line.startswith("assert")
 
 
 def pylint_assertion_messages(pylint_json_string):
-    """ Filters PyLint output to include only messages referring to assert statements """
+    """ Filters PyLint output to include only messages which referring to
+        assert statements """
     msgs = json.loads(pylint_json_string)
     return list(filter(lint_message_is_in_assertion, msgs))

--- a/pytest_encourage/util.py
+++ b/pytest_encourage/util.py
@@ -29,5 +29,6 @@ def filter_assertions(msgs: Union[str, List[LintMsg]]) -> List[LintMsg]:
     """ Filters Pylint output to include only messages which refer to
         assert statements """
     if isinstance(msgs, str):
+        # If passing in a JSON string, parse it to get a List[LintMsg] object
         msgs = json.loads(msgs)
     return list(filter(lint_message_is_in_assertion, msgs))

--- a/pytest_encourage/util.py
+++ b/pytest_encourage/util.py
@@ -11,8 +11,12 @@ def read_source_file(filepath: str) -> List[str]:
         return lines
 
 
-def lint_message_is_in_assertion(msg: Dict[str, Union[str, int]]):
-    """ Checks whether a PyLint message is referring to an assert statement """
+# Define custom type for a Pylint message
+LintMsg = Dict[str, Union[str, int]]
+
+
+def lint_message_is_in_assertion(msg: LintMsg) -> bool:
+    """ Checks whether a Pylint message is referring to an assert statement """
     path, line_num = msg["path"], msg["line"]
     # Line numbers start with 1, not 0
     line = read_source_file(path)[line_num - 1]
@@ -21,8 +25,9 @@ def lint_message_is_in_assertion(msg: Dict[str, Union[str, int]]):
     return line.startswith("assert")
 
 
-def pylint_assertion_messages(pylint_json_string):
-    """ Filters PyLint output to include only messages which referring to
+def filter_assertions(msgs: Union[str, List[LintMsg]]) -> List[LintMsg]:
+    """ Filters Pylint output to include only messages which referring to
         assert statements """
-    msgs = json.loads(pylint_json_string)
+    if isinstance(msgs, str):
+        msgs = json.loads(msgs)
     return list(filter(lint_message_is_in_assertion, msgs))

--- a/pytest_encourage/util.py
+++ b/pytest_encourage/util.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Union
 
 
 def read_source_file(filepath: str) -> List[str]:
-    """ Decorator which reads the lines of a file and passes as arg to func """
+    """ Function which returns the lines of a file """
     # pylint: disable=invalid-name
     with open(filepath, "r") as f:
         lines = f.read().split("\n")


### PR DESCRIPTION
Adds new method in `pytest_encourage.util` to filter PyLint output, including only messages which refer to assertion statements. Fixes #3 